### PR TITLE
feat: adding a warning when using rom path containing spaces

### DIFF
--- a/src/ui/MainForm.cs
+++ b/src/ui/MainForm.cs
@@ -54,6 +54,11 @@ namespace SM64DSe
                 Program.m_ROM.EndRW();
             }
 
+            if (filename.Contains(" "))
+            {
+                MessageBox.Show("Your ROM path contains white spaces. This can cause some issues.", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            
             Program.m_IsROMFolder = false;
             Program.m_ROMPath = filename;
             try { Program.m_ROM = new NitroROM(Program.m_ROMPath); }


### PR DESCRIPTION
<img width="618" alt="image" src="https://github.com/Gota7/SM64DSe-Ultimate/assets/42176370/4c92f12a-eb23-4dca-b7b1-47fcebbb6ae7">

Adding a nice warning to avoid a lot of issues