### PR TITLE
Texture animation editor update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj/
 .vs/
 .idea
 packages
+.ignore/*

--- a/src/core/ImportExport/LevelImportExport/LevelExporterV1.cs
+++ b/src/core/ImportExport/LevelImportExport/LevelExporterV1.cs
@@ -522,8 +522,8 @@ namespace SM64DSe.ImportExport.LevelImportExport
                     writer.WriteElementString("NumberOfFrames", texAnim.m_NumFrames.ToString());
                     writer.WriteElementString("NumberOfAnimations", texAnim.m_NumDefs.ToString());
 
-                    List<float> scales = texAnim.m_Defs.SelectMany(y => y.m_ScaleValues).ToList();
-                    List<int> scalesInt = texAnim.m_Defs.SelectMany(y => y.m_ScaleValuesInt).ToList();
+                    List<float> scales = texAnim.m_Defs.SelectMany(y => y.m_ScaleYValues).ToList();
+                    List<int> scalesInt = texAnim.m_Defs.SelectMany(y => y.m_ScaleYValuesInt).ToList();
                     List<float> rotations = texAnim.m_Defs.SelectMany(y => y.m_RotationValues).ToList();
                     List<int> rotationsInt = texAnim.m_Defs.SelectMany(y => y.m_RotationValuesInt).ToList();
                     List<float> translations = texAnim.m_Defs.SelectMany(y => y.m_TranslationXValues).ToList();
@@ -553,8 +553,8 @@ namespace SM64DSe.ImportExport.LevelImportExport
                         writer.WriteStartElement("TextureAnimation");
 
                         writer.WriteElementString("MaterialName", def.m_MaterialName);
-                        writer.WriteElementString("ScaleStartIndex", Helper.FindSubList(scales, def.m_ScaleValues).ToString());
-                        writer.WriteElementString("ScaleLength", def.m_NumScaleValues.ToString());
+                        writer.WriteElementString("ScaleStartIndex", Helper.FindSubList(scales, def.m_ScaleYValues).ToString());
+                        writer.WriteElementString("ScaleLength", def.m_NumScaleYValues.ToString());
                         writer.WriteElementString("RotationStartIndex", Helper.FindSubList(rotations, def.m_RotationValues).ToString());
                         writer.WriteElementString("RotationLength", def.m_NumRotationValues.ToString());
                         writer.WriteElementString("TranslationStartIndex", Helper.FindSubList(translations, def.m_TranslationXValues).ToString());

--- a/src/core/ImportExport/LevelImportExport/LevelExporterV2.cs
+++ b/src/core/ImportExport/LevelImportExport/LevelExporterV2.cs
@@ -56,8 +56,8 @@ namespace SM64DSe.ImportExport.LevelImportExport
                     writer.WriteElementString("NumberOfFrames", texAnim.m_NumFrames.ToString());
                     writer.WriteElementString("NumberOfAnimations", texAnim.m_NumDefs.ToString());
 
-                    List<float> scaleValues = texAnim.m_Defs.SelectMany(y => y.m_ScaleValues).ToList();
-                    List<int> scaleValuesInt = texAnim.m_Defs.SelectMany(y => y.m_ScaleValuesInt).ToList();
+                    List<float> scaleValues = texAnim.m_Defs.SelectMany(y => y.m_CombinedScaleValues).ToList();
+                    List<int> scaleValuesInt = texAnim.m_Defs.SelectMany(y => y.m_CombinedScaleValuesInt).ToList();
                     List<float> rotationValues = texAnim.m_Defs.SelectMany(y => y.m_RotationValues).ToList();
                     List<int> rotationValuesInt = texAnim.m_Defs.SelectMany(y => y.m_RotationValuesInt).ToList();
                     List<float> translationValues = texAnim.m_Defs.SelectMany(y => y.m_CombinedTranslationValues).ToList();
@@ -73,8 +73,10 @@ namespace SM64DSe.ImportExport.LevelImportExport
 
                         writer.WriteElementString("MaterialName", def.m_MaterialName);
                         writer.WriteElementString("DefaultScaleValue", def.m_DefaultScale.ToString());
-                        writer.WriteElementString("ScaleStartIndex", Helper.FindSubList(scaleValues, def.m_ScaleValues).ToString());
-                        writer.WriteElementString("ScaleLength", def.m_NumScaleValues.ToString());
+                        writer.WriteElementString("ScaleXStartIndex", Helper.FindSubList(scaleValues, def.m_ScaleXValues).ToString());
+                        writer.WriteElementString("ScaleXLength", def.m_NumScaleXValues.ToString());
+                        writer.WriteElementString("ScaleYStartIndex", Helper.FindSubList(scaleValues, def.m_ScaleYValues).ToString());
+                        writer.WriteElementString("ScaleYLength", def.m_NumScaleYValues.ToString());
                         writer.WriteElementString("RotationStartIndex", Helper.FindSubList(rotationValues, def.m_RotationValues).ToString());
                         writer.WriteElementString("RotationLength", def.m_NumRotationValues.ToString());
                         writer.WriteElementString("TranslationXStartIndex", Helper.FindSubList(translationValues, def.m_TranslationXValues).ToString());

--- a/src/core/ImportExport/LevelImportExport/LevelImporterV1.cs
+++ b/src/core/ImportExport/LevelImportExport/LevelImporterV1.cs
@@ -577,7 +577,7 @@ namespace SM64DSe.ImportExport.LevelImportExport
                 }
                 else if (reader.NodeType.Equals(XmlNodeType.EndElement) && reader.LocalName.Equals("TextureAnimation"))
                 {
-                    texAnim.m_ScaleValues = scales.GetRange(scaleStart, scaleLength);
+                    texAnim.m_ScaleYValues = scales.GetRange(scaleStart, scaleLength);
                     texAnim.m_RotationValues = rotations.GetRange(rotationStart, rotationLength);
                     texAnim.m_TranslationXValues = translations.GetRange(translationStart, translationLength);
                     return texAnim;

--- a/src/core/ImportExport/LevelImportExport/LevelImporterV2.cs
+++ b/src/core/ImportExport/LevelImportExport/LevelImporterV2.cs
@@ -145,7 +145,8 @@ namespace SM64DSe.ImportExport.LevelImportExport
         {
             LevelTexAnim.Def texAnim = new LevelTexAnim.Def();
 
-            int scaleStart = 0, scaleLength = 0;
+            int scaleXStart = 0, scaleXLength = 0;
+            int scaleYStart = 0, scaleYLength = 0;
             int rotationStart = 0, rotationLength = 0;
             int translationXStart = 0, translationXLength = 0;
             int translationYStart = 0, translationYLength = 0;
@@ -161,13 +162,21 @@ namespace SM64DSe.ImportExport.LevelImportExport
                 {
                     texAnim.m_DefaultScale = uint.Parse(reader.ReadElementContentAsString()) / 4096f;
                 }
-                else if (reader.NodeType.Equals(XmlNodeType.Element) && reader.LocalName.Equals("ScaleStartIndex"))
+                else if (reader.NodeType.Equals(XmlNodeType.Element) && reader.LocalName.Equals("ScaleXStartIndex"))
                 {
-                    scaleStart = reader.ReadElementContentAsInt();
+                    scaleXStart = reader.ReadElementContentAsInt();
                 }
-                else if (reader.NodeType.Equals(XmlNodeType.Element) && reader.LocalName.Equals("ScaleLength"))
+                else if (reader.NodeType.Equals(XmlNodeType.Element) && reader.LocalName.Equals("ScaleXLength"))
                 {
-                    scaleLength = reader.ReadElementContentAsInt();
+                    scaleXLength = reader.ReadElementContentAsInt();
+                }
+                else if (reader.NodeType.Equals(XmlNodeType.Element) && (reader.LocalName.Equals("ScaleYStartIndex") || reader.LocalName.Equals("ScaleStartIndex")))
+                {
+                    scaleYStart = reader.ReadElementContentAsInt();
+                }
+                else if (reader.NodeType.Equals(XmlNodeType.Element) && (reader.LocalName.Equals("ScaleYLength") || reader.LocalName.Equals("ScaleLength")))
+                {
+                    scaleYLength = reader.ReadElementContentAsInt();
                 }
                 else if (reader.NodeType.Equals(XmlNodeType.Element) && reader.LocalName.Equals("RotationStartIndex"))
                 {
@@ -195,7 +204,8 @@ namespace SM64DSe.ImportExport.LevelImportExport
                 }
                 else if (reader.NodeType.Equals(XmlNodeType.EndElement) && reader.LocalName.Equals("TextureAnimation"))
                 {
-                    texAnim.m_ScaleValues = scales.GetRange(scaleStart, scaleLength);
+                    texAnim.m_ScaleXValues = scales.GetRange(scaleXStart, scaleXLength);
+                    texAnim.m_ScaleYValues = scales.GetRange(scaleYStart, scaleYLength);
                     texAnim.m_RotationValues = rotations.GetRange(rotationStart, rotationLength);
                     texAnim.m_TranslationXValues = translations.GetRange(translationXStart, translationXLength);
                     texAnim.m_TranslationYValues = translations.GetRange(translationYStart, translationYLength);

--- a/src/core/LevelObject.cs
+++ b/src/core/LevelObject.cs
@@ -1560,28 +1560,34 @@ namespace SM64DSe
                 def.m_MaterialName = ovl.ReadString(ovl.ReadPointer(animOffset + 0x04), -1);
                 def.m_DefaultScale = ovl.Read32(animOffset + 0x08);
 
-                uint numScale = ovl.Read16(animOffset + 0x0C);
-                uint numRot   = ovl.Read16(animOffset + 0x10);
+                uint numScaleX = ovl.Read16(animOffset + 0x08);
+                uint numScaleY = ovl.Read16(animOffset + 0x0C);
+                uint numRot    = ovl.Read16(animOffset + 0x10);
                 uint numTransX = ovl.Read16(animOffset + 0x14);
                 uint numTransY = ovl.Read16(animOffset + 0x18);
 
-                uint scaleIndex = ovl.Read16(animOffset + 0x0E);
-                uint rotIndex   = ovl.Read16(animOffset + 0x12);
+                uint scaleXIndex = ovl.Read16(animOffset + 0x0A);
+                uint scaleYIndex = ovl.Read16(animOffset + 0x0E);
+                uint rotIndex    = ovl.Read16(animOffset + 0x12);
                 uint transXIndex = ovl.Read16(animOffset + 0x16);
                 uint transYIndex = ovl.Read16(animOffset + 0x1A);
 
-                def.m_ScaleValues = new List<float>((int)numScale);
+                def.m_ScaleXValues = new List<float>((int)numScaleX);
+                def.m_ScaleYValues = new List<float>((int)numScaleY);
                 def.m_RotationValues   = new List<float>((int)numRot);
                 def.m_TranslationXValues = new List<float>((int)numTransX);
                 def.m_TranslationYValues = new List<float>((int)numTransY);
 
-                uint scaleStartOffset = scaleOffset + (scaleIndex * 4);
+                uint scaleXStartOffset = scaleOffset + (scaleXIndex * 4);
+                uint scaleYStartOffset = scaleOffset + (scaleYIndex * 4);
                 uint rotationStartOffset = rotOffset + (rotIndex * 2);
                 uint translationXStartOffset = transOffset + (transXIndex * 4);
                 uint translationYStartOffset = transOffset + (transYIndex * 4);
 
-                for (uint offs = scaleStartOffset; offs < scaleStartOffset + numScale * 4; offs += 4)
-                    def.m_ScaleValues.Add((int)ovl.Read32(offs) / 4096.0f);
+                for (uint offs = scaleXStartOffset; offs < scaleXStartOffset + numScaleX * 4; offs += 4)
+                    def.m_ScaleXValues.Add((int)ovl.Read32(offs) / 4096.0f);
+                for (uint offs = scaleYStartOffset; offs < scaleYStartOffset + numScaleY * 4; offs += 4)
+                    def.m_ScaleYValues.Add((int)ovl.Read32(offs) / 4096.0f);
                 for (uint offs = rotationStartOffset; offs < rotationStartOffset + numRot * 2; offs += 2)
                     def.m_RotationValues  .Add((short)ovl.Read16(offs) / 4096.0f * 360.0f);
                 for (uint offs = translationXStartOffset; offs < translationXStartOffset + numTransX * 4; offs += 4)
@@ -1643,7 +1649,7 @@ namespace SM64DSe
         public static void SaveAll(System.IO.BinaryWriter binWriter, List<LevelTexAnim> texAnimList, uint areaTableOffset, uint numAreas)
         {
             List<int> scaleValues = CombineTransformValues(
-                texAnimList.Select(x => x.m_Defs.Select(y => y.m_ScaleValuesInt.ToList())
+                texAnimList.Select(x => x.m_Defs.Select(y => y.m_CombinedScaleValuesInt.ToList())
                     .ToList()).ToList());
             List<int> rotationValues   = CombineTransformValues(
                 texAnimList.Select(x => x.m_Defs.Select(y => y.m_RotationValuesInt.ToList())
@@ -1678,21 +1684,24 @@ namespace SM64DSe
                 uint defStrPtrOffset = (uint)binWriter.BaseStream.Position + 0x04;
                 foreach (Def def in texAnim.m_Defs)
                 {
-                    List<int> currScaleValues = def.m_ScaleValuesInt;
+                    List<int> currScaleXValues = def.m_ScaleXValuesInt;
+                    List<int> currScaleYValues = def.m_ScaleYValuesInt;
                     List<int> currRotationValues = def.m_RotationValuesInt;
                     List<int> currTranslationXValues = def.m_TranslationXValuesInt;
                     List<int> currTranslationYValues = def.m_TranslationYValuesInt;
 
-                    int numScaleValues = def.m_ScaleValues.Count;
+                    int numScaleXValues = def.m_ScaleXValues.Count;
+                    int numScaleYValues = def.m_ScaleYValues.Count;
                     int numRotationValues = def.m_RotationValues.Count;
                     int numTranslationXValues = def.m_TranslationXValues.Count;
                     int numTranslationYValues = def.m_TranslationYValues.Count;
 
                     binWriter.Write(0x0000ffff);
                     binWriter.Write(0x00000000);
-                    binWriter.Write(0x00000001);
-                    binWriter.Write((ushort)numScaleValues);
-                    binWriter.Write((ushort)Helper.FindSubList(scaleValues, currScaleValues));
+                    binWriter.Write((ushort)numScaleXValues);
+                    binWriter.Write((ushort)Helper.FindSubList(scaleValues, currScaleXValues));
+                    binWriter.Write((ushort)numScaleYValues);
+                    binWriter.Write((ushort)Helper.FindSubList(scaleValues, currScaleYValues));
                     binWriter.Write((ushort)numRotationValues);
                     binWriter.Write((ushort)Helper.FindSubList(rotationValues, currRotationValues));
                     binWriter.Write((ushort)numTranslationXValues);
@@ -1716,7 +1725,8 @@ namespace SM64DSe
         
         public uint m_NumFrames;
 
-        public int m_NumScaleValues { get { int count = 0; foreach (Def def in m_Defs) { count += def.m_NumScaleValues; } return count; } }
+        public int m_NumScaleXValues { get { int count = 0; foreach (Def def in m_Defs) { count += def.m_NumScaleXValues; } return count; } }
+        public int m_NumScaleYValues { get { int count = 0; foreach (Def def in m_Defs) { count += def.m_NumScaleYValues; } return count; } }
         public int m_NumRotationValues { get { int count = 0; foreach (Def def in m_Defs) { count += def.m_NumRotationValues; } return count; } }
         public int m_NumTranslationXValues { get { int count = 0; foreach (Def def in m_Defs) { count += def.m_NumTranslationXValues; } return count; } }
         public int m_NumTranslationYValues { get { int count = 0; foreach (Def def in m_Defs) { count += def.m_NumTranslationYValues; } return count; } }
@@ -1724,18 +1734,21 @@ namespace SM64DSe
         public class Def
         {
             public string m_MaterialName;
-            public List<float> m_ScaleValues = new List<float>();
+            public List<float> m_ScaleXValues = new List<float>();
+            public List<float> m_ScaleYValues = new List<float>();
             public List<float> m_RotationValues = new List<float>();
             public List<float> m_TranslationXValues = new List<float>();
             public List<float> m_TranslationYValues = new List<float>();
             public float m_DefaultScale = 1;
 
-            public int m_NumScaleValues { get { return (m_ScaleValues != null) ? m_ScaleValues.Count : 0; } }
+            public int m_NumScaleXValues { get { return (m_ScaleXValues != null) ? m_ScaleXValues.Count : 0; } }
+            public int m_NumScaleYValues { get { return (m_ScaleYValues != null) ? m_ScaleYValues.Count : 0; } }
             public int m_NumRotationValues { get { return (m_RotationValues != null) ? m_RotationValues.Count : 0; } }
             public int m_NumTranslationXValues { get { return (m_TranslationXValues != null) ? m_TranslationXValues.Count : 0; } }
             public int m_NumTranslationYValues { get { return (m_TranslationYValues != null) ? m_TranslationYValues.Count : 0; } }
 
-            public List<int> m_ScaleValuesInt { get { return Helper.FloatListTo20_12IntList(m_ScaleValues); } }
+            public List<int> m_ScaleXValuesInt { get { return Helper.FloatListTo20_12IntList(m_ScaleXValues); } }
+            public List<int> m_ScaleYValuesInt { get { return Helper.FloatListTo20_12IntList(m_ScaleYValues); } }
             public List<int> m_RotationValuesInt { get { return Helper.FloatListToRotationIntList(m_RotationValues); } }
             public List<int> m_TranslationXValuesInt { get { return Helper.FloatListTo20_12IntList(m_TranslationXValues); } }
             public List<int> m_TranslationYValuesInt { get { return Helper.FloatListTo20_12IntList(m_TranslationYValues); } }
@@ -1748,6 +1761,17 @@ namespace SM64DSe
                     translations.AddRange(m_TranslationXValues);
                     translations.AddRange(m_TranslationYValues);
                     return translations;
+                }
+            }
+            public List<int> m_CombinedScaleValuesInt { get { return Helper.FloatListTo20_12IntList(m_CombinedScaleValues); } }
+            public List<float> m_CombinedScaleValues
+            {
+                get
+                {
+                    List<float> scales = new List<float>();
+                    scales.AddRange(m_ScaleXValues);
+                    scales.AddRange(m_ScaleYValues);
+                    return scales;
                 }
             }
             public List<int> m_CombinedTranslationValuesInt { get { return Helper.FloatListTo20_12IntList(m_CombinedTranslationValues); } }

--- a/src/core/LevelObject.cs
+++ b/src/core/LevelObject.cs
@@ -1682,16 +1682,22 @@ namespace SM64DSe
                     List<int> currRotationValues = def.m_RotationValuesInt;
                     List<int> currTranslationXValues = def.m_TranslationXValuesInt;
                     List<int> currTranslationYValues = def.m_TranslationYValuesInt;
+
+                    int numScaleValues = def.m_ScaleValues.Count;
+                    int numRotationValues = def.m_RotationValues.Count;
+                    int numTranslationXValues = def.m_TranslationXValues.Count;
+                    int numTranslationYValues = def.m_TranslationYValues.Count;
+
                     binWriter.Write(0x0000ffff);
                     binWriter.Write(0x00000000);
                     binWriter.Write(0x00000001);
-                    binWriter.Write((ushort)def.m_ScaleValues.Count);
+                    binWriter.Write((ushort)numScaleValues);
                     binWriter.Write((ushort)Helper.FindSubList(scaleValues, currScaleValues));
-                    binWriter.Write((ushort)def.m_RotationValues.Count);
+                    binWriter.Write((ushort)numRotationValues);
                     binWriter.Write((ushort)Helper.FindSubList(rotationValues, currRotationValues));
-                    binWriter.Write((ushort)def.m_TranslationXValues.Count);
+                    binWriter.Write((ushort)numTranslationXValues);
                     binWriter.Write((ushort)Helper.FindSubList(translationValues, currTranslationXValues));
-                    binWriter.Write((ushort)def.m_TranslationYValues.Count);
+                    binWriter.Write((ushort)numTranslationYValues);
                     binWriter.Write((ushort)Helper.FindSubList(translationValues, currTranslationYValues));
                 }
                 foreach (Def def in texAnim.m_Defs)

--- a/src/core/formats/BMD.cs
+++ b/src/core/formats/BMD.cs
@@ -1045,9 +1045,10 @@ namespace SM64DSe
                                             {
                                                 if (entry.m_MaterialName == matgroup.m_Name)
                                                 {
-
-                                                    float scaleValue = LevelTexAnim.AnimationValue(entry.m_ScaleValues, texAnimFrame, (int)texAnim.m_NumFrames);
-                                                    coord = coord * scaleValue;
+                                                    float scaleX = LevelTexAnim.AnimationValue(entry.m_ScaleXValues, texAnimFrame, (int)texAnim.m_NumFrames);
+                                                    float scaleY = LevelTexAnim.AnimationValue(entry.m_ScaleYValues, texAnimFrame, (int)texAnim.m_NumFrames);
+                                                    coord.X *= scaleX;
+                                                    coord.Y *= scaleY;
 
                                                     float angle = LevelTexAnim.AnimationValue(entry.m_RotationValues, texAnimFrame, (int)texAnim.m_NumFrames);
                                                     coord = Vector2.Transform(coord, Quaternion.FromAxisAngle(Vector3.UnitZ, (angle + matgroup.m_TexCoordRot) * 0.0174533f));

--- a/src/ui/TextureAnimationForm.cs
+++ b/src/ui/TextureAnimationForm.cs
@@ -50,7 +50,7 @@ namespace SM64DSe
             txtMaterialName.Text = texAnimDef.m_MaterialName;
             txtNumFrames.Text = texAnim.m_NumFrames.ToString();
             lbxScaleValues.Items.Clear();
-            for (int i = 0; i < texAnimDef.m_ScaleValues.Count; i++)
+            for (int i = 0; i < texAnimDef.m_ScaleYValues.Count; i++)
             {
                 lbxScaleValues.Items.Add("Scale value " + i.ToString("D4"));
             }
@@ -69,7 +69,7 @@ namespace SM64DSe
             {
                 lbxTranslationYValues.Items.Add("Translation Y value " + i.ToString("D4"));
             }
-            txtScaleLength.Text = texAnimDef.m_NumScaleValues.ToString();
+            txtScaleLength.Text = texAnimDef.m_NumScaleYValues.ToString();
             txtRotationLength.Text = texAnimDef.m_NumRotationValues.ToString();
             txtTranslationXLength.Text = texAnimDef.m_NumTranslationXValues.ToString();
             txtTranslationYLength.Text = texAnimDef.m_NumTranslationYValues.ToString();
@@ -123,7 +123,7 @@ namespace SM64DSe
 
         private float ReadScaleValue(int area, int texAnim, int index)
         {
-            return m_Level.m_TexAnims[area].m_Defs[texAnim].m_ScaleValues[index];
+            return m_Level.m_TexAnims[area].m_Defs[texAnim].m_ScaleYValues[index];
         }
 
         private float ReadRotationValue(int area, int texAnim, int index)
@@ -143,7 +143,7 @@ namespace SM64DSe
 
         private void SetScaleValue(float value, int area, int texAnim, int index)
         {
-            m_Level.m_TexAnims[area].m_Defs[texAnim].m_ScaleValues[index] = value;
+            m_Level.m_TexAnims[area].m_Defs[texAnim].m_ScaleYValues[index] = value;
         }
 
         private void SetRotationValue(float value, int area, int texAnim, int index)
@@ -163,7 +163,7 @@ namespace SM64DSe
 
         private void AddScaleValue(float value, int area, int texAnim, int index)
         {
-            m_Level.m_TexAnims[area].m_Defs[texAnim].m_ScaleValues.Insert(index, value);
+            m_Level.m_TexAnims[area].m_Defs[texAnim].m_ScaleYValues.Insert(index, value);
         }
 
         private void AddRotationValue(float value, int area, int texAnim, int index)
@@ -183,7 +183,7 @@ namespace SM64DSe
 
         private void SetScaleSize(ushort value, int area, int texAnim)
         {
-            Helper.ResizeList(m_Level.m_TexAnims[area].m_Defs[texAnim].m_ScaleValues, value, 1.0f);
+            Helper.ResizeList(m_Level.m_TexAnims[area].m_Defs[texAnim].m_ScaleYValues, value, 1.0f);
         }
 
         private void SetRotationSize(ushort value, int area, int texAnim)
@@ -203,7 +203,7 @@ namespace SM64DSe
 
         private void RemoveScaleValue(int area, int texAnim, int index)
         {
-            m_Level.m_TexAnims[area].m_Defs[texAnim].m_ScaleValues.RemoveAt(index);
+            m_Level.m_TexAnims[area].m_Defs[texAnim].m_ScaleYValues.RemoveAt(index);
         }
 
         private void RemoveRotationValue(int area, int texAnim, int index)

--- a/src/ui/textures/BetterTextureAnimationEditor.Designer.cs
+++ b/src/ui/textures/BetterTextureAnimationEditor.Designer.cs
@@ -382,7 +382,8 @@
             "Translation X",
             "Translation Y",
             "Rotation",
-            "Scale"});
+            "Scale X",
+            "Scale Y"});
             this.cbSelectProperty.Location = new System.Drawing.Point(2, 32);
             this.cbSelectProperty.Name = "cbSelectProperty";
             this.cbSelectProperty.Size = new System.Drawing.Size(131, 21);

--- a/src/ui/textures/BetterTextureAnimationEditor.cs
+++ b/src/ui/textures/BetterTextureAnimationEditor.cs
@@ -26,7 +26,8 @@ namespace SM64DSe.SM64DSFormats
         private float m_translationX = 0;
         private float m_translationY = 0;
         private float m_rotation = 0;
-        private float m_scale = 1;
+        private float m_scaleX = 1;
+        private float m_scaleY = 1;
         
         private System.Windows.Forms.Timer m_texAnimTimer;
         private int m_texAnimFrame = 0;
@@ -47,7 +48,8 @@ namespace SM64DSe.SM64DSFormats
             TRANSLATION_X = 0,
             TRANSLATION_Y = 1,
             ROTATION = 2,
-            SCALE = 3
+            SCALE_X = 3,
+            SCALE_Y = 4,
         }
 
         private float m_zoomFactor = 1;
@@ -108,14 +110,16 @@ namespace SM64DSe.SM64DSFormats
                 m_translationX = LevelTexAnim.AnimationValue(m_animEntry.m_TranslationXValues, 0, 0);
                 m_translationY = LevelTexAnim.AnimationValue(m_animEntry.m_TranslationYValues, 0, 0);
                 m_rotation = LevelTexAnim.AnimationValue(m_animEntry.m_RotationValues, 0, 0);
-                m_scale = LevelTexAnim.AnimationValue(m_animEntry.m_ScaleValues, 0, 0);
+                m_scaleX = LevelTexAnim.AnimationValue(m_animEntry.m_ScaleXValues, 0, 0);
+                m_scaleY = LevelTexAnim.AnimationValue(m_animEntry.m_ScaleYValues, 0, 0);
             }
             else
             {
                 m_translationX = 0;
                 m_translationY = 0;
                 m_rotation = 0;
-                m_scale = 1;
+                m_scaleX = 1;
+                m_scaleY = 1;
             }
 
             SetupGUIForPauseMode();
@@ -129,7 +133,8 @@ namespace SM64DSe.SM64DSFormats
                 m_translationX = LevelTexAnim.AnimationValue(m_animEntry.m_TranslationXValues, m_texAnimFrame, (int)m_animations[m_animId].m_NumFrames);
                 m_translationY = LevelTexAnim.AnimationValue(m_animEntry.m_TranslationYValues, m_texAnimFrame, (int)m_animations[m_animId].m_NumFrames);
                 m_rotation = LevelTexAnim.AnimationValue(m_animEntry.m_RotationValues, m_texAnimFrame, (int)m_animations[m_animId].m_NumFrames);
-                m_scale = LevelTexAnim.AnimationValue(m_animEntry.m_ScaleValues, m_texAnimFrame, (int)m_animations[m_animId].m_NumFrames);
+                m_scaleX = LevelTexAnim.AnimationValue(m_animEntry.m_ScaleXValues, m_texAnimFrame, (int)m_animations[m_animId].m_NumFrames);
+                m_scaleY = LevelTexAnim.AnimationValue(m_animEntry.m_ScaleYValues, m_texAnimFrame, (int)m_animations[m_animId].m_NumFrames);
             }
             if (valueSettingPanel2.Visible)
             {
@@ -139,8 +144,10 @@ namespace SM64DSe.SM64DSFormats
                     m_translationY = InterpolatedValue(m_keyFrames, m_texAnimFrame) * (float)numScaling.Value;
                 else if ((AnimationProperty)cbSelectProperty.SelectedIndex == AnimationProperty.ROTATION)
                     m_rotation = InterpolatedValue(m_keyFrames, m_texAnimFrame) * (float)numScaling.Value;
-                else if ((AnimationProperty)cbSelectProperty.SelectedIndex == AnimationProperty.SCALE)
-                    m_scale = InterpolatedValue(m_keyFrames, m_texAnimFrame) * (float)numScaling.Value;
+                else if ((AnimationProperty)cbSelectProperty.SelectedIndex == AnimationProperty.SCALE_X)
+                    m_scaleX = InterpolatedValue(m_keyFrames, m_texAnimFrame) * (float)numScaling.Value;
+                else if ((AnimationProperty)cbSelectProperty.SelectedIndex == AnimationProperty.SCALE_Y)
+                    m_scaleY = InterpolatedValue(m_keyFrames, m_texAnimFrame) * (float)numScaling.Value;
             }
             m_texAnimFrame %= (int)m_animations[m_animId].m_NumFrames;
             m_timelineFrame = m_texAnimFrame % 120;
@@ -272,7 +279,8 @@ namespace SM64DSe.SM64DSFormats
                         m_TranslationXValues = new List<float>(entry.m_TranslationXValues),
                         m_TranslationYValues = new List<float>(entry.m_TranslationYValues),
                         m_RotationValues = new List<float>(entry.m_RotationValues),
-                        m_ScaleValues = new List<float>(entry.m_ScaleValues),
+                        m_ScaleXValues = new List<float>(entry.m_ScaleXValues),
+                        m_ScaleYValues = new List<float>(entry.m_ScaleYValues),
                     };
 
                     if (newEntry.m_TranslationXValues.Count == 0)
@@ -281,8 +289,10 @@ namespace SM64DSe.SM64DSFormats
                         newEntry.m_TranslationYValues.Add(0f);
                     if (newEntry.m_RotationValues.Count == 0)
                         newEntry.m_RotationValues.Add(0f);
-                    if (newEntry.m_ScaleValues.Count == 0)
-                        newEntry.m_ScaleValues.Add(1f);
+                    if (newEntry.m_ScaleXValues.Count == 0)
+                        newEntry.m_ScaleXValues.Add(1f);
+                    if (newEntry.m_ScaleYValues.Count == 0)
+                        newEntry.m_ScaleYValues.Add(1f);
 
                     m_entries.Add(entry.m_MaterialName, newEntry);
                 }
@@ -328,8 +338,10 @@ namespace SM64DSe.SM64DSFormats
                     m_animationValues.Add(Helper.Wrap(value,360f));
                 }
             }
-            else
-                m_animationValues = m_animEntry.m_ScaleValues;
+            else if (property == AnimationProperty.SCALE_X)
+                m_animationValues = m_animEntry.m_ScaleXValues;
+            else if (property == AnimationProperty.SCALE_Y)
+                m_animationValues = m_animEntry.m_ScaleYValues;
             foreach (float value in m_animationValues)
             {
                 if (value < m_valueFloor)
@@ -338,7 +350,7 @@ namespace SM64DSe.SM64DSFormats
                     m_valueCeiling = value;
             }
             if (m_animationValues.Count == 0)
-                m_animationValues.Add((property == AnimationProperty.SCALE) ? 1 : 0);
+                m_animationValues.Add((property == AnimationProperty.SCALE_X || property == AnimationProperty.SCALE_Y) ? 1 : 0);
             UpdateAnimation();
         }
 
@@ -369,7 +381,7 @@ namespace SM64DSe.SM64DSFormats
             //UV Rectangle
             Pen pen = new Pen(Color.Gold, 2);
             double angle = m_rotation * 0.0174533f;
-            RectangleF rect = new RectangleF(-32 * m_scale, -32 * m_scale, 64 * m_scale, 64 * m_scale);
+            RectangleF rect = new RectangleF(-32 * m_scaleX, -32 * m_scaleY, 64 * m_scaleX, 64 * m_scaleY);
             PointF center = new PointF(m_UVwindowRect.Width / 2f + m_translationX * 64 * m_zoomFactor, m_UVwindowRect.Height / 2f - m_translationY * 64 * m_zoomFactor);
 
             gfx.DrawPolygon(pen, new PointF[] {
@@ -392,9 +404,9 @@ namespace SM64DSe.SM64DSFormats
             //small Texture Preview Window
             texBrush.ResetTransform();
             if (texWidth > texHeight)
-                texBrush.ScaleTransform(32 / texWidth / m_scale, 32 / texWidth / m_scale);
+                texBrush.ScaleTransform(32 / texWidth / m_scaleX, 32 / texWidth / m_scaleY);
             else
-                texBrush.ScaleTransform(32 / texHeight / m_scale, 32 / texHeight / m_scale);
+                texBrush.ScaleTransform(32 / texHeight / m_scaleX, 32 / texHeight / m_scaleY);
             texBrush.TranslateTransform(width - 32 - m_translationX * 64, 32 + m_translationY * 64);
             texBrush.RotateTransform(-m_rotation);
             gfx.FillRectangle(texBrush, width - 64, 0, 64, 64);
@@ -627,7 +639,8 @@ namespace SM64DSe.SM64DSFormats
                 float value;
                 if (m_animationValues.Count > 0)
                     value = m_animationValues.Last();
-                else if ((AnimationProperty)cbSelectProperty.SelectedIndex == AnimationProperty.SCALE)
+                else if ((AnimationProperty)cbSelectProperty.SelectedIndex == AnimationProperty.SCALE_X
+                    || (AnimationProperty)cbSelectProperty.SelectedIndex == AnimationProperty.SCALE_Y)
                     value = 1;
                 else
                     value = 0;
@@ -680,8 +693,10 @@ namespace SM64DSe.SM64DSFormats
                         m_animEntry.m_RotationValues.Add(wrappedValue-360);
                 }
             }
-            else
-                m_animEntry.m_ScaleValues = m_animationValues;
+            else if (property == AnimationProperty.SCALE_X)
+                m_animEntry.m_ScaleXValues = m_animationValues;
+            else if (property == AnimationProperty.SCALE_Y)
+                m_animEntry.m_ScaleYValues = m_animationValues;
 
             if (m_unsavedEntries[m_animId].ContainsKey(m_animEntry.m_MaterialName))
                 m_unsavedEntries[m_animId][m_animEntry.m_MaterialName] = m_animEntry;
@@ -722,7 +737,8 @@ namespace SM64DSe.SM64DSFormats
             animEntry.m_TranslationXValues = OptimizeValues(animEntry.m_TranslationXValues);
             animEntry.m_TranslationYValues = OptimizeValues(animEntry.m_TranslationYValues);
             animEntry.m_RotationValues = OptimizeValues(animEntry.m_RotationValues);
-            animEntry.m_ScaleValues = OptimizeValues(animEntry.m_ScaleValues);
+            animEntry.m_ScaleXValues = OptimizeValues(animEntry.m_ScaleXValues);
+            animEntry.m_ScaleYValues = OptimizeValues(animEntry.m_ScaleYValues);
             return animEntry;
         }
 
@@ -764,7 +780,8 @@ namespace SM64DSe.SM64DSFormats
             m_animEntry.m_TranslationXValues = new List<float>(new float[] { 0f });
             m_animEntry.m_TranslationYValues = new List<float>(new float[] { 0f });
             m_animEntry.m_RotationValues = new List<float>(new float[] { 0f });
-            m_animEntry.m_ScaleValues = new List<float>(new float[] { 1f });
+            m_animEntry.m_ScaleXValues = new List<float>(new float[] { 1f });
+            m_animEntry.m_ScaleYValues = new List<float>(new float[] { 1f });
 
             if (m_unsavedEntries[m_animId].ContainsKey(m_animEntry.m_MaterialName))
                 m_unsavedEntries[m_animId][m_animEntry.m_MaterialName] = m_animEntry;
@@ -789,13 +806,12 @@ namespace SM64DSe.SM64DSFormats
             {
                 m_DefaultScale = 1,
                 m_MaterialName = tvMaterials.SelectedNode.Name,
-                m_TranslationXValues = new List<float>(new float[] { 1f }),
-                m_TranslationYValues = new List<float>(new float[] { 1f }),
+                m_TranslationXValues = new List<float>(new float[] { 0f }),
+                m_TranslationYValues = new List<float>(new float[] { 0f }),
                 m_RotationValues = new List<float>(new float[] { 0f }),
-                m_ScaleValues = new List<float>(new float[] { 1f })
+                m_ScaleXValues = new List<float>(new float[] { 1f }),
+                m_ScaleYValues = new List<float>(new float[] { 1f })
             };
-            newEntry.m_RotationValues.Add(0);
-            newEntry.m_ScaleValues.Add(1);
 
             if (m_entries.ContainsKey(tvMaterials.SelectedNode.Name))
                 m_entries[tvMaterials.SelectedNode.Name] = newEntry;
@@ -861,11 +877,17 @@ namespace SM64DSe.SM64DSFormats
                         m_animEntry.m_RotationValues.Add(wrappedValue - 360);
                 }
             }
-            else
+            else if (property == AnimationProperty.SCALE_X)
             {
-                m_animEntry.m_ScaleValues = new List<float>();
+                m_animEntry.m_ScaleXValues = new List<float>();
                 for (int i = 0; i < m_animations[m_animId].m_NumFrames; i++)
-                    m_animEntry.m_ScaleValues.Add(InterpolatedValue(m_keyFrames, i) * (float)numScaling.Value);
+                    m_animEntry.m_ScaleXValues.Add(InterpolatedValue(m_keyFrames, i) * (float)numScaling.Value);
+            }
+            else if (property == AnimationProperty.SCALE_Y)
+            {
+                m_animEntry.m_ScaleYValues = new List<float>();
+                for (int i = 0; i < m_animations[m_animId].m_NumFrames; i++)
+                    m_animEntry.m_ScaleYValues.Add(InterpolatedValue(m_keyFrames, i) * (float)numScaling.Value);
             }
 
             //add to unsaved

--- a/src/ui/textures/BetterTextureAnimationEditor.cs
+++ b/src/ui/textures/BetterTextureAnimationEditor.cs
@@ -275,6 +275,15 @@ namespace SM64DSe.SM64DSFormats
                         m_ScaleValues = new List<float>(entry.m_ScaleValues),
                     };
 
+                    if (newEntry.m_TranslationXValues.Count == 0)
+                        newEntry.m_TranslationXValues.Add(0f);
+                    if (newEntry.m_TranslationYValues.Count == 0)
+                        newEntry.m_TranslationYValues.Add(0f);
+                    if (newEntry.m_RotationValues.Count == 0)
+                        newEntry.m_RotationValues.Add(0f);
+                    if (newEntry.m_ScaleValues.Count == 0)
+                        newEntry.m_ScaleValues.Add(1f);
+
                     m_entries.Add(entry.m_MaterialName, newEntry);
                 }
 
@@ -686,8 +695,6 @@ namespace SM64DSe.SM64DSFormats
             //Console.WriteLine(materialName);
             List<LevelTexAnim.Def> newEntries = new List<LevelTexAnim.Def>();
 
-
-
             foreach (LevelTexAnim.Def entry in m_parent.m_Level.m_TexAnims[area].m_Defs)
             {
                 if (entry.m_MaterialName == materialName) {
@@ -743,12 +750,21 @@ namespace SM64DSe.SM64DSFormats
 
         private void btnSaveAnim_Click(object sender, EventArgs e)
         {
-            SaveAnimation(m_animId, m_animEntry.m_MaterialName);
+            int area = m_animId;
+            string materialName = m_animEntry.m_MaterialName;
+
+            if (!m_unsavedEntries[area].ContainsKey(materialName))
+                m_unsavedEntries[area].Add(materialName, m_animEntry);
+
+            SaveAnimation(area, materialName);
         }
 
         private void btnDeleteAnim_Click(object sender, EventArgs e)
         {
-            m_animEntry.m_RotationValues = new List<float>();
+            m_animEntry.m_TranslationXValues = new List<float>(new float[] { 0f });
+            m_animEntry.m_TranslationYValues = new List<float>(new float[] { 0f });
+            m_animEntry.m_RotationValues = new List<float>(new float[] { 0f });
+            m_animEntry.m_ScaleValues = new List<float>(new float[] { 1f });
 
             if (m_unsavedEntries[m_animId].ContainsKey(m_animEntry.m_MaterialName))
                 m_unsavedEntries[m_animId][m_animEntry.m_MaterialName] = m_animEntry;
@@ -773,10 +789,10 @@ namespace SM64DSe.SM64DSFormats
             {
                 m_DefaultScale = 1,
                 m_MaterialName = tvMaterials.SelectedNode.Name,
-                m_TranslationXValues = new List<float>(),
-                m_TranslationYValues = new List<float>(),
-                m_RotationValues = new List<float>(),
-                m_ScaleValues = new List<float>()
+                m_TranslationXValues = new List<float>(new float[] { 1f }),
+                m_TranslationYValues = new List<float>(new float[] { 1f }),
+                m_RotationValues = new List<float>(new float[] { 0f }),
+                m_ScaleValues = new List<float>(new float[] { 1f })
             };
             newEntry.m_RotationValues.Add(0);
             newEntry.m_ScaleValues.Add(1);


### PR DESCRIPTION
* New texture animations are now initialised correctly (with default values 0 for translation / rotation and 1 for scale).
* Broken texture animations (with invalid properties, aka any property with count set to 0) can now be fixed by saving the broken animation, the editor will fix them by adding the default values to the invalid animation properties, giving them the required minimum count of 1.
* The scale property of texture animations has now been split into 2 properties, to enable independant X and Y scaling. The editor previously only read and wrote to the Y scaling values, with the X scale always being set to the first value of the Y scale.